### PR TITLE
default site pointing to 2026 site

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=https://ossfe.github.io/OSSFE_2025">
+    <meta http-equiv="refresh" content="0; url=https://ossfe.github.io/OSSFE_2026">
     <title>Redirecting...</title>
 </head>
 <body>
-    <p>If you are not redirected automatically, follow this <a href="https://ossfe.github.io/OSSFE_2025">link</a>.</p>
+    <p>If you are not redirected automatically, follow this <a href="https://ossfe.github.io/OSSFE_2026">link</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
I think we are ready to leave 2025 behind

The 2026 site has a link back to the 2025 site for those who need it